### PR TITLE
Javy bless plugins - LLM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blockless-sdk"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4567ec9632cf48e7a5225b5a075f334f1c8a364d4ff9692925d58de1b17dcb0c"
+dependencies = [
+ "json",
+]
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +1576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "javy-bless-plugins"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "blockless-sdk",
+ "javy-plugin-api",
+]
+
+[[package]]
 name = "javy-cli"
 version = "5.0.1"
 dependencies = [
@@ -1672,6 +1690,12 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/plugin-api",
   "crates/test-macros",
   "crates/test-plugin",
+  "crates/bless-plugins",
   "crates/runner",
   "fuzz",
 ]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,31 @@ size.
 Pre-compiled binaries of the Javy CLI can be found on [the releases
 page](https://github.com/bytecodealliance/javy/releases).
 
+## Build bls-javy and plugins
+
+```sh
+# build the core plugins
+cargo build --release --target wasm32-wasip1 -p javy-plugin
+```
+
+```sh
+# build test plugin (for testing)
+cargo build --target=wasm32-wasip1 --release -p javy-test-plugin
+# rebuild the plugin with javy runtime
+cargo run -p javy-cli -- init-plugin ./target/wasm32-wasip1/release/test_plugin.wasm -o test_plugin.wasm
+# compile javascript to wasm with javy runtime and plugin
+cargo run -p javy-cli -- build -C plugin=test_plugin.wasm ./llm-test.js -o llm-test.wasm && mv llm-test.wasm ~/Downloads
+```
+
+```sh
+# build bless plugins
+cargo build --target=wasm32-wasip1 --release -p javy-bless-plugins
+# rebuild the plugin with javy runtime
+cargo run -p javy-cli -- init-plugin ./target/wasm32-wasip1/release/bless_plugins.wasm -o bless_plugins.wasm
+# compile javascript to wasm with javy runtime and plugin
+cargo run -p javy-cli -- build -C plugin=bless_plugins.wasm ./llm-test.js -o llm-test.wasm && mv llm-test.wasm ~/Downloads
+```
+
 ## Example
 
 Define your JavaScript like:

--- a/crates/bless-plugins/Cargo.toml
+++ b/crates/bless-plugins/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "javy-bless-plugins"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "bless_plugins"
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = { workspace = true }
+javy-plugin-api = { path = "../plugin-api", features = ["json"] }
+blockless-sdk = { version = "0.1.6" }


### PR DESCRIPTION
# Description

Introducing new crate to utilize in *bless plugins* for the host bless runtime.

This PR introduces support for the following plugin (brower-runtime only at this moment):
- `blockless_llm`

The core LLM plugin is implemented in the [`sdk-rust`](https://github.com/blocklessnetwork/sdk-rust) - [here](https://github.com/blocklessnetwork/sdk-rust/blob/main/src/llm.rs).
- This PR creates a javy-compatible plugin which creates exposes the `BlessLLM` function to global scope and makes it callable via a javascript file - which utilizes the host runtimes LLM plugin.

## Usage of plugin in JS

Create the following file:

```javascript
// llm-test.js

// Create instance
const llm = BlessLLM("Llama-3.1-8B-Instruct-q4f32_1-MLC");

// Set options
llm.setOptions({
    system_message: "You are a helpful assistant. First time I ask, your name will be Lucy. Second time I ask, your name will be Bob."
});

// Chat
console.log(llm.chat("What is your name?"));
console.log(llm.chat("What is your name?"));
```

Build and move to downloads folder:

```sh
# build bless plugins
cargo build --target=wasm32-wasip1 --release -p javy-bless-plugins
# rebuild the plugin with javy runtime
cargo run -p javy-cli -- init-plugin ./target/wasm32-wasip1/release/bless_plugins.wasm -o bless_plugins.wasm
# compile javascript to wasm with javy runtime and plugin
cargo run -p javy-cli -- build -C plugin=bless_plugins.wasm ./llm-test.js -o llm-test.wasm && mv llm-test.wasm ~/Downloads
```

- Now test this in browser runtime.