### PR TITLE
support gblic2.33

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -109,10 +109,10 @@ jobs:
             asset_name: javy-x86_64-linux-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum
             target: x86_64-unknown-linux-gnu
-          - name: linux
-            os: ubuntu-20.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
-            path: target/x86_64-unknown-linux-gnu/release/javy
-            asset_name: javy-x86_64-linux-${{ github.event.release.tag_name }}
+          - name: linux-glibc2.33
+            os: ubuntu-22.04 # Use oldest supported non-deprecated version so we link against older glibc version which allows running binary on a wider set of Linux systems
+            path: javy-glibc2.33
+            asset_name: javy-x86_64-linux-glibc2.33-${{ github.event.release.tag_name }}
             shasum_cmd: sha256sum
             target: x86_64-unknown-linux-gnu
           - name: linux-arm64
@@ -156,6 +156,13 @@ jobs:
         with:
           name: plugin
           path: target/wasm32-wasip1/release/
+      
+      - name: Build CLI ${{ matrix.os }}
+        if: matrix.name == 'linux-glibc2.33'
+        run: |
+          docker build -t javy-cli .
+          ci=$(docker create javy-cli)
+          docker cp $ci:/target/x86_64-unknown-linux-gnu/release/javy javy-glibc2.33
 
       - name: Build CLI ${{ matrix.os }}
         run: cargo build --release --target ${{ matrix.target }} --package javy-cli


### PR DESCRIPTION
## Description of the change

## Why am I making this change?

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
