### PR TITLE
support gblic2.33

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/wasm32-wasip1/release/build/
+target/wasm32-wasip1/release/deps/
+target/wasm32-wasip1/release/incremental/
+target/aarch64-unknown-linux-musl/
+target/aarchx86_64-unknown-linux-musl/
+target/release/
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+COPY . .
+COPY target/wasm32-wasip1/release/plugin.wasm target/wasm32-wasip1/release/plugin.wasm
+COPY target/wasm32-wasip1/release/plugin_wizened.wasm target/wasm32-wasip1/release/plugin_wizened.wasm
+ENV TARGET=x86_64-unknown-linux-gnu
+RUN apt-get update -y && apt-get install -y gcc-x86-64-linux-gnu g++-x86-64-linux-gnu curl
+SHELL ["/bin/bash", "-c"]
+RUN echo $HOME
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs |  bash -s -- -y
+RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+RUN source $HOME/.cargo/env && cargo build --release --target ${TARGET} --package javy-cli


### PR DESCRIPTION
## Description of the change

## Why am I making this change?

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-plugin` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
